### PR TITLE
Version 1.1

### DIFF
--- a/cogs/listeners/on_channel_delete.py
+++ b/cogs/listeners/on_channel_delete.py
@@ -10,8 +10,8 @@ class Channel_Delete(commands.Cog):
 
     @commands.Cog.listener()
     async def on_guild_channel_delete(self, channel: GuildChannel) -> None: # Runs when a channel is deleted
-        if channel.id in get_channels(channel.guild): # If channel is in database remove it, preventing future errors
-            remove_channel(channel.guild, channel.id)
+        if channel.id in get_channels(channel.guild.id): # If channel is in database remove it, preventing future errors
+            remove_channel(channel.guild.id, channel.id)
 
 def setup(client: Bot):
     client.add_cog(Channel_Delete(client))


### PR DESCRIPTION
Fixed an error with SQL in `on_channel_delete` that caused the guild name to be passed instead of the id